### PR TITLE
Add CDN URL prefix when adding rule

### DIFF
--- a/qianka/flaskext/flask.py
+++ b/qianka/flaskext/flask.py
@@ -177,7 +177,7 @@ class QKFlask(Flask):
                 self.webassets.directory, filename, cache_timeout=cache_timeout)
 
         self.add_url_rule(
-            '/assets/<path:filename>',
+            '%s/assets/<path:filename>' % self.config['CDN_URL_PREFIX_ASSETS'],
             endpoint='assets',
             view_func=_send_assets_file
         )


### PR DESCRIPTION
这个好像是一个 bug，如果设置了 `CDN_URL_PREFIX_ASSETS` 会出现可以正确 build url 但是无法找到这个路径的问题。
